### PR TITLE
Add Channel Genre Flow with Database Integration

### DIFF
--- a/core/database/src/commonMain/kotlin/br/tv/ole/service/ChannelGenreService.kt
+++ b/core/database/src/commonMain/kotlin/br/tv/ole/service/ChannelGenreService.kt
@@ -1,0 +1,45 @@
+package br.tv.ole.service
+
+import br.tv.ole.DatabaseScope
+import br.tv.ole.db.ChannelGenre
+import br.tv.ole.transactionWithContext
+import kotlinx.coroutines.withContext
+
+interface ChannelGenreService {
+    suspend fun selectAllChannelGenres(): List<ChannelGenre>
+    suspend fun insertChannelGenre(genres: List<ChannelGenre>)
+    suspend fun deleteChannelGenreByOrder(order: Long)
+    suspend fun updateChannelGenre(genre: ChannelGenre)
+}
+
+fun DatabaseScope.channelGenreService() = object : ChannelGenreService {
+    private val log = logger.withTag("ChannelGenreService")
+    private val query = databaseRef.channelGenreQueries
+
+    override suspend fun selectAllChannelGenres(): List<ChannelGenre> = withContext(backgroundDispatcher) {
+        query.selectAllChannelGenre().executeAsList()
+    }
+
+    override suspend fun insertChannelGenre(genres: List<ChannelGenre>) =
+        databaseRef.transactionWithContext(backgroundDispatcher) {
+            genres.forEach { genre ->
+                query.insertChannelGenre(order = genre.order, name = genre.name)
+            }
+        }.also {
+            log.i { "Inserting ${genres.size} Channel Genre into database" }
+        }
+
+    override suspend fun deleteChannelGenreByOrder(order: Long) =
+        databaseRef.transactionWithContext(backgroundDispatcher) {
+            query.deleteChannelGenreByOrder(order)
+        }.also {
+            log.i { "Deleting Channel Genre with order $order from database" }
+        }
+
+    override suspend fun updateChannelGenre(genre: ChannelGenre) =
+        databaseRef.transactionWithContext(backgroundDispatcher) {
+            query.updateChannelGenre(name = genre.name, order = genre.order)
+        }.also {
+            log.i { "Channel order ${genre.name} is being updated" }
+        }
+}

--- a/core/database/src/commonMain/kotlin/br/tv/ole/service/ChannelService.kt
+++ b/core/database/src/commonMain/kotlin/br/tv/ole/service/ChannelService.kt
@@ -10,6 +10,7 @@ interface ChannelService {
     suspend fun selectLastWatchedChannels(): List<Channel>
     suspend fun selectById(id: Long): Channel?
     suspend fun insertChannels(channels: List<Channel>)
+    suspend fun updateChannel(channel: Channel)
     suspend fun deleteChannelById(id: Long)
 }
 
@@ -47,7 +48,26 @@ fun DatabaseScope.channelService() = object : ChannelService {
                 )
             }
         }.also {
-            log.i { "Inserting ${channels.size} channels into database" }
+            log.i { "Inserting ${channels.size} Channels into database" }
+        }
+
+    override suspend fun updateChannel(channel: Channel) =
+        databaseRef.transactionWithContext(backgroundDispatcher) {
+            query.updateChannel(
+                id = channel.id,
+                number = channel.number,
+                name = channel.name,
+                genre = channel.genre,
+                type = channel.type,
+                classification = channel.classification,
+                epgHash = channel.epgHash,
+                hasCatchUp = channel.hasCatchUp,
+                hasStartOver = channel.hasStartOver,
+                isFavorite = channel.isFavorite,
+                watchingTime = channel.watchingTime,
+            )
+        }.also {
+            log.i { "Channel ${channel.id} is being updated" }
         }
 
     override suspend fun deleteChannelById(id: Long) =

--- a/core/database/src/commonMain/sqldelight/br/tv/ole/db/ChannelGenre.sq
+++ b/core/database/src/commonMain/sqldelight/br/tv/ole/db/ChannelGenre.sq
@@ -1,0 +1,23 @@
+CREATE TABLE ChannelGenre (
+    `order` INTEGER NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+selectAllChannelGenre:
+SELECT * FROM ChannelGenre
+ORDER BY `order` DESC;
+
+insertChannelGenre:
+INSERT INTO ChannelGenre (
+    `order`,
+    name
+) VALUES (?, ?);
+
+updateChannelGenre:
+UPDATE ChannelGenre
+SET
+    name = ?
+WHERE `order` = ?;
+
+deleteChannelGenreByOrder:
+DELETE FROM ChannelGenre WHERE `order` = ?;

--- a/data/channel/src/commonMain/kotlin/br/tv/ole/mapper/ChannelGenreMappers.kt
+++ b/data/channel/src/commonMain/kotlin/br/tv/ole/mapper/ChannelGenreMappers.kt
@@ -1,0 +1,11 @@
+package br.tv.ole.mapper
+
+import br.tv.ole.model.ChannelGenre
+
+fun br.tv.ole.db.ChannelGenre.asModel(): ChannelGenre {
+    return ChannelGenre(order = order, name = name)
+}
+
+fun ChannelGenre.toData(): br.tv.ole.db.ChannelGenre {
+    return br.tv.ole.db.ChannelGenre(order = order, name = name)
+}

--- a/data/channel/src/commonMain/kotlin/br/tv/ole/model/ChannelGenre.kt
+++ b/data/channel/src/commonMain/kotlin/br/tv/ole/model/ChannelGenre.kt
@@ -1,0 +1,6 @@
+package br.tv.ole.model
+
+data class ChannelGenre(
+    val order: Long,
+    val name: String
+)

--- a/data/channel/src/commonMain/kotlin/br/tv/ole/repository/ChannelGenreRepository.kt
+++ b/data/channel/src/commonMain/kotlin/br/tv/ole/repository/ChannelGenreRepository.kt
@@ -1,0 +1,29 @@
+package br.tv.ole.repository
+
+import br.tv.ole.mapper.asModel
+import br.tv.ole.mapper.toData
+import br.tv.ole.model.ChannelGenre
+import br.tv.ole.service.ChannelGenreService
+
+interface ChannelGenreRepository {
+    suspend fun selectAllChannelGenres(): List<ChannelGenre>
+    suspend fun insertChannelGenre(genres: List<ChannelGenre>)
+    suspend fun deleteChannelGenreByOrder(order: Long)
+    suspend fun updateChannelGenre(genre: ChannelGenre)
+}
+
+fun channelGenreRepository(
+    channelGenreService: ChannelGenreService,
+) = object : ChannelGenreRepository {
+    override suspend fun selectAllChannelGenres(): List<ChannelGenre> =
+        channelGenreService.selectAllChannelGenres().map { it.asModel() }
+
+    override suspend fun insertChannelGenre(genres: List<ChannelGenre>) =
+        channelGenreService.insertChannelGenre(genres.map { it.toData() })
+
+    override suspend fun deleteChannelGenreByOrder(order: Long) =
+        channelGenreService.deleteChannelGenreByOrder(order)
+
+    override suspend fun updateChannelGenre(genre: ChannelGenre) =
+        channelGenreService.updateChannelGenre(genre.toData())
+}

--- a/data/channel/src/commonMain/kotlin/br/tv/ole/repository/ChannelRepository.kt
+++ b/data/channel/src/commonMain/kotlin/br/tv/ole/repository/ChannelRepository.kt
@@ -9,6 +9,7 @@ interface ChannelRepository {
     suspend fun getAllChannels(): List<Channel>
     suspend fun getLastWatchedChannels(): List<Channel>
     suspend fun insertChannel(channel: List<Channel>)
+    suspend fun updateChannel(channel: Channel)
     suspend fun deleteChannelById(id: Long)
 }
 
@@ -23,6 +24,9 @@ fun channelRepository(
 
     override suspend fun insertChannel(channel: List<Channel>) =
         channelService.insertChannels(channel.map { it.toData() })
+
+    override suspend fun updateChannel(channel: Channel) =
+        channelService.updateChannel(channel.toData())
 
     override suspend fun deleteChannelById(id: Long) =
         channelService.deleteChannelById(id)


### PR DESCRIPTION
- Added `Channel Genre` to the database schema.
- Implemented service, data layer, and repository support for `Channel Genre`.
- Enabled local flow for managing channel genres within the application.